### PR TITLE
[App-58]: remove Assets host serving of images, stylesheets, and JavaScripts from an asset server in Production config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,9 +27,6 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = "http://assets.example.com"
-
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX


### PR DESCRIPTION
remove Assets host serving of images, stylesheets, and JavaScripts from an asset server in Production config