### PR TITLE
[App-71]: add Bundler dependencies security check job to GithubActions CI workflow via Bundler-Audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,22 @@ name: Continuous-Integration
 on: [push]
 
 jobs:
+  BundlerAudit:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and Install Gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Verify Bundler
+        run: |
+          bundle exec bundler-audit update
+          bundle exec bundler-audit check
+
   RSpec:
     runs-on: ubuntu-18.04
     services:


### PR DESCRIPTION
add Bundler dependencies security check job to GithubActions CI workflow via Bundler-Audit